### PR TITLE
Fix compiler errors

### DIFF
--- a/src/dhcp.rs
+++ b/src/dhcp.rs
@@ -169,8 +169,8 @@ impl Debug for DhcpPacket {
         };
         let chaddr: [u8; 6] = self.chaddr[0..6].try_into().unwrap();
         // FIXME: これ0終端とは限らないはず
-        let sname = unsafe { CStr::from_ptr(&self.sname as *const _) };
-        let file = unsafe { CStr::from_ptr(&self.file as *const _) };
+        let sname = unsafe { CStr::from_ptr(&self.sname as *const u8 as *const _) };
+        let file = unsafe { CStr::from_ptr(&self.file as *const u8 as *const _) };
 
         if self.options[0..4] != DHCP_COOKIE {
             log::warn!("cookie: error");
@@ -257,7 +257,7 @@ impl Debug for DhcpPacket {
             let mut buf = [0u8; 257];
             copy_nonoverlapping(*ptr, buf.as_mut_ptr(), n);
             buf[n] = 0;
-            let str = CStr::from_ptr(buf.as_ptr());
+            let str = CStr::from_ptr(buf.as_ptr() as *const i8);
             *ptr = ptr.add(n);
             writeln!(options, "\"{}\"", str.to_str().unwrap()).unwrap();
         }

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -42,7 +42,7 @@ impl IpRecvBuffer {
         // 本当は多くなりすぎたら消去するとかすべき
         match self.0.entry(id) {
             Occupied(mut o) => {
-                let mut entry = o.get_mut();
+                let entry = o.get_mut();
                 entry.id = id;
                 entry.timestamp = Local::now().timestamp();
                 entry.len = 0;
@@ -244,7 +244,7 @@ impl IpClient {
             let send_len = if fragment { max_len / 8 * 8 } else { rest };
             let ptr = send_buf.as_mut_ptr();
 
-            let mut ip = unsafe { &mut *(ptr as *mut IpHeader) };
+            let ip = unsafe { &mut *(ptr as *mut IpHeader) };
             ip.set_ip_v(4);
             ip.set_ip_hl(5);
             ip.ip_len = ((size_of::<IpHeader>() + send_len) as u16).to_be();

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ fn get_mac_address(device: &str) -> anyhow::Result<MacAddr> {
     unsafe {
         close(soc);
     }
-    Ok(hwaddr.into())
+    Ok(hwaddr.map(|e| e as u8).into())
 }
 
 fn main() -> anyhow::Result<()> {
@@ -216,9 +216,11 @@ fn main() -> anyhow::Result<()> {
                 _ => {
                     if targets[0].revents & (POLLIN | POLLERR) != 0 {
                         unsafe {
-                            fgets(&mut buf as *mut c_char, buf.len() as i32, stdin);
+                            fgets(&mut buf as *mut u8 as *mut c_char, buf.len() as i32, stdin);
                         }
-                        let args = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
+                        let args = unsafe { CStr::from_ptr(buf.as_ptr() as *const i8) }
+                            .to_str()
+                            .unwrap();
                         if let Err(e) = cmd.do_cmd(args) {
                             eprintln!("{:?}", e);
                         }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -102,7 +102,7 @@ impl UdpClient {
         let context = self.context.lock().unwrap().clone();
         let mut send_buf = [0u8; 64 * 1024];
         let mut ptr = send_buf.as_mut_ptr();
-        let mut udp = unsafe { &mut *(ptr as *mut UdpHeader) };
+        let udp = unsafe { &mut *(ptr as *mut UdpHeader) };
         udp.uh_sport = src_port.to_be();
         udp.uh_dport = dst_port.to_be();
         udp.uh_ulen = ((size_of::<UdpHeader>() + data.len()) as u16).to_be();
@@ -141,7 +141,7 @@ impl UdpClient {
         let context = self.context.lock().unwrap().clone();
         let mut send_buf = [0u8; 64 * 1024];
         let mut ptr = send_buf.as_mut_ptr();
-        let mut udp = unsafe { &mut *(ptr as *mut UdpHeader) };
+        let udp = unsafe { &mut *(ptr as *mut UdpHeader) };
         udp.uh_sport = src_port.to_be();
         udp.uh_dport = dst_port.to_be();
         udp.uh_ulen = ((size_of::<UdpHeader>() + data.len()) as u16).to_be();


### PR DESCRIPTION
- Fix compile errors caused by type mismatch in some function parameters
- Eliminate compile warnings caused by unused `mut` keyword